### PR TITLE
Implement canonical board helpers

### DIFF
--- a/games/connect4.py
+++ b/games/connect4.py
@@ -25,6 +25,22 @@ class Connect4(Game):
         print()
 
     @staticmethod
+    def get_canonical_board(board: np.ndarray, current_player: int):
+        """Return a canonical representation of ``board``.
+
+        When ``current_player`` is ``1`` the two player planes are swapped so
+        that plane ``0`` always corresponds to the current player.  The returned
+        array preserves the original shape and ``dtype``.
+        """
+        if current_player == 0:
+            return board
+        canonical = np.empty_like(board)
+        canonical[0], canonical[1] = board[1], board[0]
+        if board.shape[0] > 2:
+            canonical[2:] = board[2:]
+        return canonical
+
+    @staticmethod
     def get_action_idx(move: tuple[int, int]):
         return move[1] # col
     

--- a/games/tictactoe.py
+++ b/games/tictactoe.py
@@ -26,6 +26,22 @@ class TicTacToe(Game):
         # print(board[2])
 
     @staticmethod
+    def get_canonical_board(board: np.ndarray, current_player: int):
+        """Return a canonical representation of ``board``.
+
+        If ``current_player`` is ``1`` the first two planes are swapped so that
+        plane ``0`` always represents the current player.  The returned array
+        keeps the same shape and ``dtype`` as the input.
+        """
+        if current_player == 0:
+            return board
+        canonical = np.empty_like(board)
+        canonical[0], canonical[1] = board[1], board[0]
+        if board.shape[0] > 2:
+            canonical[2:] = board[2:]
+        return canonical
+
+    @staticmethod
     def get_action_idx(action: tuple[int, int]):
         """
         Returns:


### PR DESCRIPTION
## Summary
- mirror Gomoku's canonical board logic for Connect4 and TicTacToe
- keep board shape and dtype when swapping planes

## Testing
- `python -m py_compile games/connect4.py games/tictactoe.py`
- *(failed to run further tests due to missing `numpy`)*

------
https://chatgpt.com/codex/tasks/task_e_6857dd350158832493a9f634fd6f07fe