### PR TITLE
Enable parallel self-play

### DIFF
--- a/config.json
+++ b/config.json
@@ -11,6 +11,7 @@
     "patch_size": 5,
     "embed_dim": 512,
     "dropout": 0.1
+    ,"num_processes": 1
   },
   "model": {
     "save_dir": "models",

--- a/train_loop.py
+++ b/train_loop.py
@@ -50,7 +50,12 @@ def start_train_loop(Game, older_model, newer_model, model_version,
         print('update_count:', update_count)
         Game.logger.info(f'iteration: {i}, update_count: {update_count}')
 
-        train.collect_data(Game, older_model, buffer, iterations=collect_data_iterations, mcts_iter=mcts_iter, display=display)
+        num_processes = TRAIN_CFG.get('num_processes', 1)
+        train.collect_data(Game, older_model, buffer,
+                          iterations=collect_data_iterations,
+                          mcts_iter=mcts_iter,
+                          display=display,
+                          num_processes=num_processes)
         Game.logger.info(f'buffer status: {buffer.size()}/{buffer_size}')
         print(f'buffer status:{buffer.size()}/{buffer_size}')
         train_iterations = (buffer.size() // batch_size) * 1


### PR DESCRIPTION
## Summary
- add multiprocessing support for self-play collection
- allow configuring number of processes via `config.json`
- pass new process count through training loop

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_686e508b1050832485170534ae0df9d8